### PR TITLE
Include jest-expo in the nohoist to allow yarn test in rn-expo

### DIFF
--- a/workspaces-examples/react-native/rn-expo/package.json
+++ b/workspaces-examples/react-native/rn-expo/package.json
@@ -11,7 +11,10 @@
       "**/react-native-scripts",
       "**/react-native-scripts/**",
       "**/expo",
-      "**/expo/**"
+      "**/expo/**",
+      "**/jest-expo",
+      "**/jest-expo/**"
+      
     ]
   }
 }


### PR DESCRIPTION
Related to my comment here

https://github.com/connectdotz/yarn-nohoist-examples/issues/1 

This PR allows yarn test to run without any changes in a CRNA sub-module in a yarn workspace